### PR TITLE
Fix case of some included files

### DIFF
--- a/src/bomberman/trolley/Rail.cpp
+++ b/src/bomberman/trolley/Rail.cpp
@@ -1,4 +1,4 @@
-#include "rail.h"
+#include "Rail.h"
 
 Rail::Rail(int index, int prev, int next, int nextAlt) {
 	this->index = index;

--- a/src/bomberman/trolley/Trolley.cpp
+++ b/src/bomberman/trolley/Trolley.cpp
@@ -1,4 +1,4 @@
-#include "trolley.h"
+#include "Trolley.h"
 
 Trolley::Trolley(int index){
 


### PR DESCRIPTION
Fix the cases of some inclusions of "Rail.h" and "Trolley.h", which prevent compilation otherwise.