### PR TITLE
Add CI build for a GitHub release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+./**
+!emulationStationTheme/**
+!src/**
+!resources/**
+!Makefile*
+!*.info

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,107 @@
+name: Build and release
+
+on:
+  release:
+    types: [ published ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - classifier: x86_64
+            platform: linux/amd64
+            base-image: debian:oldoldstable-slim
+            runner: ubuntu-latest
+
+          - classifier: aarch64
+            platform: linux/arm64
+            base-image: debian:oldoldstable-slim
+            runner: ubuntu-24.04-arm
+
+          - classifier: armv7l-rpi3
+            platform: linux/arm/v7
+            subvariant: rpi3
+            base-image: debian:oldoldstable-slim
+            runner: ubuntu-24.04-arm
+
+          - classifier: armv7l-rpi2
+            platform: linux/arm/v7
+            subvariant: rpi2
+            base-image: debian:oldoldstable-slim
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: rlespinasse/github-slug-action@v4
+
+      - name: Setup qemu for docker
+        uses: docker/setup-qemu-action@v3
+        if: matrix.platform != 'linux/amd64' && matrix.platform != 'linux/arm64'
+
+      - name: Setup buildx for docker
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          outputs: build
+          build-args: |
+            BASE_IMAGE=${{ matrix.base-image }}
+            TARGET_PLATFORM=${{ matrix.platform }}
+            TARGET_SUBVARIANT=${{ matrix.subvariant }}
+            TARGET_ID=${{ matrix.classifier }}
+            VERSION=${{ env.GITHUB_REF_NAME }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: artifacts-${{ matrix.classifier }}
+          path: build/*
+          if-no-files-found: error
+
+  release:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    permissions:
+      contents: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v7
+        with:
+          pattern: artifacts-*
+          path: assets
+          merge-multiple: true
+
+      - uses: rlespinasse/github-slug-action@v5
+
+      - name: Package artifacts
+        shell: bash
+        run: |
+          cd assets
+          find . -maxdepth 1 -type f | while IFS=/ read dir file; do
+            mv -v "${file}" "${GITHUB_REPOSITORY_NAME_PART_SLUG}-${GITHUB_REF_NAME_SLUG}-${file}"
+          done
+
+      - name: Create checksum for release assets
+        shell: bash
+        run: |
+          algo="${SHA_ALGORITHM:-256}"
+          find assets -type f | while read -r asset; do
+            shasum --binary --algorithm "${algo}" "${asset}" >"${asset}.sha${algo}"
+          done
+
+      - name: Upload artifacts to GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: ${{ !startsWith(github.ref, 'refs/tags/') }}
+          files: assets/*
+          fail_on_unmatched_files: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1
+ARG BASE_IMAGE=debian:oldoldstable-slim
+FROM $BASE_IMAGE AS builder
+RUN apt-get update && apt-get install -y build-essential git libsdl2*-dev libdrm-dev libgbm-dev
+WORKDIR /build
+COPY . ./
+ARG TARGET_PLATFORM
+ARG TARGET_SUBVARIANT
+ARG TARGET_ID
+ARG VERSION
+RUN <<EOF
+  set -eu
+  case "${TARGET_SUBVARIANT-}" in
+    rpi?) sed -i "/#platform =/a platform = ${TARGET_SUBVARIANT}" Makefile.libretro ;;
+  esac
+  make clean -f Makefile.libretro
+  make -f Makefile.libretro
+  sed -i "s/^display_version = \".*\"/display_version = \"${VERSION}\"/" *.info
+  tar c -zvf "${TARGET_ID:-$(uname -m)${TARGET_SUBVARIANT:+-${TARGET_SUBVARIANT}}}.tar.gz" \
+    *.so \
+    *.info \
+    emulationStationTheme/ \
+    -C resources/image img_splash_screen.png
+EOF
+
+FROM scratch
+COPY --from=builder /build/*.tar.gz ./

--- a/lr_multi_bomberman_libretro.info
+++ b/lr_multi_bomberman_libretro.info
@@ -1,0 +1,32 @@
+# Software Information
+display_name = "Multi Bomberman"
+authors = "Alexis Puskarczyk"
+corename = "Multi Bomberman"
+categories = "Game"
+license = "GPLv2"
+supported_extensions = "desktop"
+permissions = ""
+display_version = "Git"
+
+# Hardware Information
+systemname = "Multi Bomberman"
+systemid = "multi_bomberman"
+
+# Libretro Features
+supports_no_game = "true"
+single_purpose = "true"
+database = "Multi Bomberman"
+savestate = "true"
+savestate_features = "deterministic"
+cheats = "false"
+input_descriptors = "false"
+memory_descriptors = "false"
+libretro_saves = "false"
+core_options = "true"
+load_subsystem = "false"
+hw_render = "false"
+needs_fullpath = "false"
+disk_control = "false"
+is_experimental = "false"
+
+description = "Bomberman oriented multiplayer (16 players, max of retroarch) Library core for Retroarch emulator."


### PR DESCRIPTION
This PR adds support to create a GitHub Release containing the libretro core and metadata for platforms PC, ARM 64-Bit, Raspberry Pi 2 and 3.

The outcome bundles everything that is required for integration in libretro distributions (e.g. RetroArch or Batocera).

Releases are created via GitHub Actions using parallel Docker builds. Build environment is oldest supported Debian for max compatibility. GitHub runner is chosen according to the target platform.

A demo of the [build](https://github.com/git-developer/lr-multi-bomberman/actions/runs/20480783710) and [release](https://github.com/git-developer/lr-multi-bomberman/releases/tag/1.0.0-beta6) is available. The release was tested successfully for `x86_64` and `arm64` in Batocera.